### PR TITLE
chore(gitignore): add .idea to ignore JetBrains IDE files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ test-ledger
 .yarn
 Makefile
 
+# IDE
+.idea/
+*.iml
+


### PR DESCRIPTION
Added .idea directory to .gitignore to prevent JetBrains IDE configuration files (e.g., workspace settings, run configurations) from being committed. This ensures a cleaner repository and avoids conflicts between developers using different IDE settings.