### PR TITLE
Add input_mint and output_mint to SwapEvent

### DIFF
--- a/programs/cp-swap/src/instructions/swap_base_input.rs
+++ b/programs/cp-swap/src/instructions/swap_base_input.rs
@@ -213,6 +213,11 @@ pub fn swap_base_input(ctx: Context<Swap>, amount_in: u64, minimum_amount_out: u
         }
     };
 
+    let (input_mint, output_mint) = match trade_direction {
+        TradeDirection::ZeroForOne => (pool_state.token_0_mint, pool_state.token_1_mint),
+        TradeDirection::OneForZero => (pool_state.token_1_mint, pool_state.token_0_mint),
+    };
+
     emit!(SwapEvent {
         pool_id,
         input_vault_before: total_input_token_amount,
@@ -221,7 +226,9 @@ pub fn swap_base_input(ctx: Context<Swap>, amount_in: u64, minimum_amount_out: u
         output_amount: u64::try_from(result.destination_amount_swapped).unwrap(),
         input_transfer_fee,
         output_transfer_fee,
-        base_input: true
+        base_input: true,
+        input_mint,
+        output_mint
     });
     require_gte!(constant_after, constant_before);
 

--- a/programs/cp-swap/src/instructions/swap_base_output.rs
+++ b/programs/cp-swap/src/instructions/swap_base_output.rs
@@ -153,6 +153,11 @@ pub fn swap_base_output(
         }
     };
 
+    let (input_mint, output_mint) = match trade_direction {
+        TradeDirection::ZeroForOne => (pool_state.token_0_mint, pool_state.token_1_mint),
+        TradeDirection::OneForZero => (pool_state.token_1_mint, pool_state.token_0_mint),
+    };
+
     emit!(SwapEvent {
         pool_id,
         input_vault_before: total_input_token_amount,
@@ -161,7 +166,9 @@ pub fn swap_base_output(
         output_amount: u64::try_from(result.destination_amount_swapped).unwrap(),
         input_transfer_fee,
         output_transfer_fee,
-        base_input: false
+        base_input: false,
+        input_mint,
+        output_mint
     });
     require_gte!(constant_after, constant_before);
 

--- a/programs/cp-swap/src/states/events.rs
+++ b/programs/cp-swap/src/states/events.rs
@@ -36,4 +36,6 @@ pub struct SwapEvent {
     pub input_transfer_fee: u64,
     pub output_transfer_fee: u64,
     pub base_input: bool,
+    pub input_mint: Pubkey,
+    pub output_mint: Pubkey
 }


### PR DESCRIPTION
Currently when consuming swap events, it’s not possible to tell which token is the input and which is the output just from the event, since the amounts can be either token0 or token1 depending on the trade direction.

This change adds input_mint and output_mint to the SwapEvent so that anyone parsing logs can easily see which tokens were swapped in and out. This makes it possible to calculate pool reserves and prices correctly from logs alone, without needing extra context.

No breaking changes