### PR TITLE
Fix: HIGH-01/02 fee collection recipient validation + fee rate bounds + MED-01/02 access control

### DIFF
--- a/programs/cp-swap/src/instructions/admin/collect_fund_fee.rs
+++ b/programs/cp-swap/src/instructions/admin/collect_fund_fee.rs
@@ -56,11 +56,17 @@ pub struct CollectFundFee<'info> {
     pub vault_1_mint: Box<InterfaceAccount<'info, Mint>>,
 
     /// The address that receives the collected token_0 fund fees
-    #[account(mut)]
+    #[account(
+        mut,
+        constraint = recipient_token_0_account.owner == amm_config.fund_owner @ ErrorCode::InvalidOwner
+    )]
     pub recipient_token_0_account: Box<InterfaceAccount<'info, TokenAccount>>,
 
     /// The address that receives the collected token_1 fund fees
-    #[account(mut)]
+    #[account(
+        mut,
+        constraint = recipient_token_1_account.owner == amm_config.fund_owner @ ErrorCode::InvalidOwner
+    )]
     pub recipient_token_1_account: Box<InterfaceAccount<'info, TokenAccount>>,
 
     /// The SPL program to perform token transfers

--- a/programs/cp-swap/src/instructions/admin/collect_protocol_fee.rs
+++ b/programs/cp-swap/src/instructions/admin/collect_protocol_fee.rs
@@ -57,11 +57,17 @@ pub struct CollectProtocolFee<'info> {
     pub vault_1_mint: Box<InterfaceAccount<'info, Mint>>,
 
     /// The address that receives the collected token_0 protocol fees
-    #[account(mut)]
+    #[account(
+        mut,
+        constraint = recipient_token_0_account.owner == amm_config.protocol_owner @ ErrorCode::InvalidOwner
+    )]
     pub recipient_token_0_account: Box<InterfaceAccount<'info, TokenAccount>>,
 
     /// The address that receives the collected token_1 protocol fees
-    #[account(mut)]
+    #[account(
+        mut,
+        constraint = recipient_token_1_account.owner == amm_config.protocol_owner @ ErrorCode::InvalidOwner
+    )]
     pub recipient_token_1_account: Box<InterfaceAccount<'info, TokenAccount>>,
 
     /// The SPL program to perform token transfers

--- a/programs/cp-swap/src/instructions/admin/update_config.rs
+++ b/programs/cp-swap/src/instructions/admin/update_config.rs
@@ -12,52 +12,67 @@ pub struct UpdateAmmConfig<'info> {
     /// Amm config account to be changed
     #[account(mut)]
     pub amm_config: Account<'info, AmmConfig>,
+
+    /// New protocol owner (required when param=3)
+    #[account(mut)]
+    pub new_protocol_owner: Option<Signer<'info>>,
+
+    /// New fund owner (required when param=4)
+    #[account(mut)]
+    pub new_fund_owner: Option<Signer<'info>>,
 }
 
 pub fn update_amm_config(ctx: Context<UpdateAmmConfig>, param: u8, value: u64) -> Result<()> {
     let amm_config = &mut ctx.accounts.amm_config;
     let match_param = Some(param);
     match match_param {
-        Some(0) => update_trade_fee_rate(amm_config, value),
-        Some(1) => update_protocol_fee_rate(amm_config, value),
-        Some(2) => update_fund_fee_rate(amm_config, value),
+        Some(0) => update_trade_fee_rate(amm_config, value)?,
+        Some(1) => update_protocol_fee_rate(amm_config, value)?,
+        Some(2) => update_fund_fee_rate(amm_config, value)?,
         Some(3) => {
-            let new_procotol_owner = *ctx.remaining_accounts.iter().next().unwrap().key;
-            set_new_protocol_owner(amm_config, new_procotol_owner)?;
+            let new_protocol_owner = ctx.accounts.new_protocol_owner.as_ref().ok_or(ErrorCode::InvalidOwner)?.key();
+            set_new_protocol_owner(amm_config, new_protocol_owner)?;
         }
         Some(4) => {
-            let new_fund_owner = *ctx.remaining_accounts.iter().next().unwrap().key;
+            let new_fund_owner = ctx.accounts.new_fund_owner.as_ref().ok_or(ErrorCode::InvalidOwner)?.key();
             set_new_fund_owner(amm_config, new_fund_owner)?;
         }
         Some(5) => amm_config.create_pool_fee = value,
         Some(6) => amm_config.disable_create_pool = if value == 0 { false } else { true },
-        Some(7) => update_creator_fee_rate(amm_config, value),
+        Some(7) => update_creator_fee_rate(amm_config, value)?,
         _ => return err!(ErrorCode::InvalidInput),
     }
 
     Ok(())
 }
 
-fn update_protocol_fee_rate(amm_config: &mut Account<AmmConfig>, protocol_fee_rate: u64) {
-    assert!(protocol_fee_rate <= FEE_RATE_DENOMINATOR_VALUE);
-    assert!(protocol_fee_rate + amm_config.fund_fee_rate <= FEE_RATE_DENOMINATOR_VALUE);
+fn update_protocol_fee_rate(amm_config: &mut Account<AmmConfig>, protocol_fee_rate: u64) -> Result<()> {
+    require!(protocol_fee_rate <= FEE_RATE_DENOMINATOR_VALUE, ErrorCode::InvalidInput);
+    require!(protocol_fee_rate + amm_config.fund_fee_rate <= amm_config.trade_fee_rate, ErrorCode::InvalidInput);
     amm_config.protocol_fee_rate = protocol_fee_rate;
+    Ok(())
 }
 
-fn update_trade_fee_rate(amm_config: &mut Account<AmmConfig>, trade_fee_rate: u64) {
-    assert!(trade_fee_rate + amm_config.creator_fee_rate < FEE_RATE_DENOMINATOR_VALUE);
+fn update_trade_fee_rate(amm_config: &mut Account<AmmConfig>, trade_fee_rate: u64) -> Result<()> {
+    require!(trade_fee_rate + amm_config.creator_fee_rate < FEE_RATE_DENOMINATOR_VALUE, ErrorCode::InvalidInput);
+    require!(amm_config.protocol_fee_rate + amm_config.fund_fee_rate <= trade_fee_rate, ErrorCode::InvalidInput);
+    require!(amm_config.creator_fee_rate <= trade_fee_rate, ErrorCode::InvalidInput);
     amm_config.trade_fee_rate = trade_fee_rate;
+    Ok(())
 }
 
-fn update_fund_fee_rate(amm_config: &mut Account<AmmConfig>, fund_fee_rate: u64) {
-    assert!(fund_fee_rate <= FEE_RATE_DENOMINATOR_VALUE);
-    assert!(fund_fee_rate + amm_config.protocol_fee_rate <= FEE_RATE_DENOMINATOR_VALUE);
+fn update_fund_fee_rate(amm_config: &mut Account<AmmConfig>, fund_fee_rate: u64) -> Result<()> {
+    require!(fund_fee_rate <= FEE_RATE_DENOMINATOR_VALUE, ErrorCode::InvalidInput);
+    require!(fund_fee_rate + amm_config.protocol_fee_rate <= amm_config.trade_fee_rate, ErrorCode::InvalidInput);
     amm_config.fund_fee_rate = fund_fee_rate;
+    Ok(())
 }
 
-fn update_creator_fee_rate(amm_config: &mut Account<AmmConfig>, creator_fee_rate: u64) {
-    assert!(creator_fee_rate + amm_config.trade_fee_rate < FEE_RATE_DENOMINATOR_VALUE);
+fn update_creator_fee_rate(amm_config: &mut Account<AmmConfig>, creator_fee_rate: u64) -> Result<()> {
+    require!(creator_fee_rate + amm_config.trade_fee_rate < FEE_RATE_DENOMINATOR_VALUE, ErrorCode::InvalidInput);
+    require!(creator_fee_rate <= amm_config.trade_fee_rate, ErrorCode::InvalidInput);
     amm_config.creator_fee_rate = creator_fee_rate;
+    Ok(())
 }
 
 fn set_new_protocol_owner(amm_config: &mut Account<AmmConfig>, new_owner: Pubkey) -> Result<()> {

--- a/programs/cp-swap/src/instructions/initialize_with_permission.rs
+++ b/programs/cp-swap/src/instructions/initialize_with_permission.rs
@@ -157,6 +157,7 @@ pub struct InitializeWithPermission<'info> {
             payer.key().as_ref(),
         ],
         bump,
+        constraint = permission.authority == payer.key() @ ErrorCode::InvalidOwner
     )]
     pub permission: Box<Account<'info, Permission>>,
 

--- a/programs/cp-swap/src/lib.rs
+++ b/programs/cp-swap/src/lib.rs
@@ -4,6 +4,7 @@ pub mod instructions;
 pub mod states;
 pub mod utils;
 use crate::curve::fees::FEE_RATE_DENOMINATOR_VALUE;
+use crate::error::ErrorCode;
 use anchor_lang::prelude::*;
 use instructions::*;
 pub use states::CreatorFeeOn;
@@ -64,10 +65,11 @@ pub mod raydium_cp_swap {
         create_pool_fee: u64,
         creator_fee_rate: u64,
     ) -> Result<()> {
-        assert!(trade_fee_rate + creator_fee_rate < FEE_RATE_DENOMINATOR_VALUE);
-        assert!(protocol_fee_rate <= FEE_RATE_DENOMINATOR_VALUE);
-        assert!(fund_fee_rate <= FEE_RATE_DENOMINATOR_VALUE);
-        assert!(fund_fee_rate + protocol_fee_rate <= FEE_RATE_DENOMINATOR_VALUE);
+        require!(trade_fee_rate + creator_fee_rate < FEE_RATE_DENOMINATOR_VALUE, ErrorCode::InvalidInput);
+        require!(protocol_fee_rate <= FEE_RATE_DENOMINATOR_VALUE, ErrorCode::InvalidInput);
+        require!(fund_fee_rate <= FEE_RATE_DENOMINATOR_VALUE, ErrorCode::InvalidInput);
+        require!(fund_fee_rate + protocol_fee_rate <= trade_fee_rate, ErrorCode::InvalidInput);
+        require!(creator_fee_rate <= trade_fee_rate, ErrorCode::InvalidInput);
         instructions::create_amm_config(
             ctx,
             index,


### PR DESCRIPTION
## Summary

Fixes **2 HIGH** and **2 MEDIUM** severity vulnerabilities found during security audit of Raydium CP-Swap.

## Vulnerabilities Fixed

### HIGH-01: Arbitrary Recipient in `collect_fund_fee` / `collect_protocol_fee`
**Impact:** Admin/fund_owner/protocol_owner could drain fees to arbitrary wallet
**Fix:** Added constraint `recipient_token_X_account.owner == amm_config.fund_owner/protocol_owner`

### HIGH-02: Fee Rate Validation Bypass
**Impact:** `fund_fee_rate + protocol_fee_rate` can exceed `trade_fee_rate`, allowing fees > trade fee
**Fix:** Added `require!(fund_fee_rate + protocol_fee_rate <= trade_fee_rate)` in create/update config

### MED-01: `update_amm_config` Owner Changes Without Signer Check
**Impact:** Admin can change protocol_owner/fund_owner to arbitrary address without their consent
**Fix:** Added explicit `new_protocol_owner` and `new_fund_owner` as `Option<Signer>` with explicit constraints

### MED-02: `permission.authority` Not Verified Against `payer`
**Impact:** Admin could create permission PDA for address A, but payer B could initialize pool
**Fix:** Added `constraint = permission.authority == payer.key()`

## Fee Rate Validation Fixes
- `create_amm_config`: Added `fund_fee_rate + protocol_fee_rate <= trade_fee_rate` and `creator_fee_rate <= trade_fee_rate`
- `update_amm_config`: All fee rate setters now validate against `trade_fee_rate`
- Changed `assert!` to `require!` with proper `ErrorCode::InvalidInput`

## Files Changed
- `instructions/admin/collect_fund_fee.rs` - recipient validation
- `instructions/admin/collect_protocol_fee.rs` - recipient validation
- `instructions/admin/update_config.rs` - fee bounds + signer for owner changes
- `instructions/initialize_with_permission.rs` - permission authority validation
- `lib.rs` (create_amm_config) - fee rate validation in `create_amm_config`

## Testing
All 10 existing tests pass:
```
test curve::constant_product::tests::constant_product_swap_rounding ... ok
test curve::constant_product::tests::curve_value_does_not_decrease_from_deposit ... ok
test curve::constant_product::tests::curve_value_does_not_decrease_from_swap ... ok
test curve::constant_product::tests::curve_value_does_not_decrease_from_withdraw ... ok
test curve::constant_product::tests::fail_trading_token_conversion ... ok
test curve::constant_product::tests::trading_token_conversion ... ok
test states::oracle::observation_test::observation_state_size_test ... ok
test states::pool::pool_test::pool_state_size_test ... ok
test states::pool::pool_test::pool_status_test::get_set_status_by_bit ... ok
test test_id ... ok
```